### PR TITLE
Add some checks for Date objects

### DIFF
--- a/spec/deserialize_function_spec.ts
+++ b/spec/deserialize_function_spec.ts
@@ -29,6 +29,10 @@ class T4 {
     @deserializeAs(Date) dateList : Array<Date>;
 }
 
+class T5 {
+    @deserializeAs(Date) date: Date;
+}
+
 class JsonTest {
     @deserialize public obj : any;
 
@@ -114,6 +118,13 @@ describe('Deserialize', function () {
         expect(result instanceof Date).toBe(true);
     });
 
+    it('should deserialize a date even when it\'s not a string', function () {
+        var d = new Date();
+        var result = Deserialize(d, Date);
+        expect(result instanceof Date).toBe(true);
+        expect(result.toString()).toEqual(d.toString())
+    });
+
     it('should deserialize a regex', function () {
         var r = /hi/;
         var regexStr = r.toString();
@@ -134,12 +145,21 @@ describe('Deserialize', function () {
     it('should deserialize a nested array as a type', function () {
         var d1 = new Date();
         var d2 = new Date();
-        var t4 = { dateList: [d1.toString(), d2.toString()] };
+        var d3 = new Date();
+        var t4 = { dateList: [d1.toString(), d2.toString(), d3] };
         var result = Deserialize(t4, T4);
         expect(result instanceof T4).toBeTruthy();
         expect(Array.isArray(result.dateList)).toBe(true);
         expect(result.dateList[0].toString()).toEqual(d1.toString());
         expect(result.dateList[1].toString()).toEqual(d2.toString());
+        expect(result.dateList[2].toString()).toEqual(d3.toString());
+    });
+
+    it('should deserialize a Date property even if source is a Date object', function () {
+        var t5 = { date: new Date() }
+        var result = Deserialize(t5, T5);
+        expect(result instanceof T5).toBeTruthy();
+        expect(result.date.toString()).toEqual(t5.date.toString());
     });
 
     it('should call OnDeserialize if defined on parent and or child', function () {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -418,7 +418,7 @@ function deserializeObjectInto(json : any, type : Function|ISerializable, instan
             }
         }
         //if the type is a Date, reconstruct a real date instance
-        else if (typeof source === "string" && metadata.deserializedType === Date) {
+        else if ((typeof source === "string" || source instanceof Date) && metadata.deserializedType === Date) {
             var deserializedDate = new Date(source);
             if (instance[keyName] instanceof Date) {
                 instance[keyName].setTime(deserializedDate.getTime());
@@ -461,7 +461,7 @@ export function Deserialize(json : any, type? : Function|ISerializable) : any {
     else if (json && typeof json === "object") {
         return deserializeObject(json, type);
     }
-    else if (typeof json === "string" && type === Date) {
+    else if ((typeof json === "string" || json instanceof Date) && type === Date) {
         return new Date(json);
     }
     else if (typeof json === "string" && type === RegExp) {
@@ -554,7 +554,7 @@ function deserializeObject(json : any, type : Function|ISerializable) : any {
         else if (Array.isArray(source)) {
             instance[keyName] = deserializeArray(source, metadata.deserializedType || null);
         }
-        else if (typeof source === "string" && metadata.deserializedType === Date) {
+        else if ((typeof source === "string" || source instanceof Date) && metadata.deserializedType === Date) {
             instance[keyName] = new Date(source);
         }
         else if (typeof source === "string" && metadata.deserializedType === RegExp) {


### PR DESCRIPTION
When dealing with multiple sources, some which don't support more than JSON and others (like BSON) who know about Dates, we have to deserialize dates that are sometimes string, sometimes Date. This fix makes sure it works in both case (and should not have any impact besides this)
